### PR TITLE
feat: add devcontainer config files, enable one-click GitHub Codespaces

### DIFF
--- a/.devcontainer/docs-development/devcontainer.json
+++ b/.devcontainer/docs-development/devcontainer.json
@@ -1,0 +1,29 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
+{
+	"name": "Airbyte DevContainer (Docs)",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:0-20",
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {},
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "cd docusaurus && yarn install",
+	// Use 'postStartCommand' to run commands after the container is started.
+	"postAttachCommand": "cd docusaurus && yarn start",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"extensions.ignoreRecommendations": true
+			}
+		}
+	}
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/java-development/devcontainer.json
+++ b/.devcontainer/java-development/devcontainer.json
@@ -1,0 +1,40 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/java
+{
+    "name": "Airbyte DevContainer (Java)",
+
+    // Version and config requirements documented in Airbyte Docs:
+    // https://docs.airbyte.com/contributing-to-airbyte/developing-locally/#develop-on-airbyte-webapp
+    "image": "mcr.microsoft.com/devcontainers/java:0-17",
+    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+
+    "features": {
+        "ghcr.io/devcontainers/features/java:1": {
+            "version": "none",
+            "installMaven": "true",
+            "installGradle": "true"
+        },
+        "ghcr.io/devcontainers/features/node": "16"
+    },
+
+    // Use 'postCreateCommand' to run commands after the container is created.
+    // "postCreateCommand": "java -version",
+
+    // Configure tool-specific properties.
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "vscjava.vscode-gradle"
+            ],
+            "settings": {
+                "extensions.ignoreRecommendations": true
+            }
+        }
+    }
+
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "root"
+}

--- a/.devcontainer/python-development/devcontainer.json
+++ b/.devcontainer/python-development/devcontainer.json
@@ -1,0 +1,36 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+    "name": "Airbyte DevContainer (Python)",
+
+    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    "image": "mcr.microsoft.com/devcontainers/python:0-3.9",
+
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    "features": {
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+        "ghcr.io/devcontainers-contrib/features/poetry:2": {}
+    },
+
+    // Configure tool-specific properties.
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.python"
+            ],
+            "settings": {
+                // Disable nagging to recommend extensions not listed here.
+                "extensions.ignoreRecommendations": true
+            }
+        }
+    }
+
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+
+    // Use 'postCreateCommand' to run commands after the container is created.
+    // "postCreateCommand": "pip3 install --user -r requirements.txt",
+
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "root"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+bin/
 .gradle
 .idea
 *.iml


### PR DESCRIPTION
## What

This PR adds dev container config files for Java, Python, and "Docs". Enables [GitHub Codespaces](https://github.com/features/codespaces) and [Prebuilds](https://docs.github.com/en/codespaces/prebuilding-your-codespaces/configuring-prebuilds).

## How

Three named devcontainer configs. 

New Codespace DX screenshot:

<img width="806" alt="image" src="https://github.com/aaronsteers/airbyte/assets/18150651/faae5a5e-01fa-4bba-8343-fbf5d98ee0c7">

Test-drive with [this link](https://github.com/codespaces/new?hide_repo_select=true&repo=631006736).

Codespaces currently allows the following container sizes:

<img width="798" alt="image" src="https://github.com/aaronsteers/airbyte/assets/18150651/b4ae5f21-61e4-44e7-b58b-f6c6e31c952a">


## 🚨 User Impact 🚨

No breaking changes or impact to users. That said, it may take a few iterations before the devcontainer configs are exactly dialed in.

